### PR TITLE
Plasma - Releases: only build latest AMD and NVIDIA versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,18 +86,12 @@ jobs:
     strategy:
       matrix:
         gpu-type:
-          # radeon
-          - gpu: AMD
-            driver: "1.0"
           # amdgpu
           - gpu: AMD
             driver: "4.0"
           # Latest prod
           - gpu: NVIDIA
             driver: "570.144"
-          # Legacy
-          - gpu: NVIDIA
-            driver: "470.256.02"
 
     steps:
       - name: Download Cached image


### PR DESCRIPTION
This is because the proportions of other usages are very small
- AMD 1.0 are very old cards, should not represent many users
- Most NVIDIA users will need to build their own versions, so any other than latest does not make sense